### PR TITLE
feat: add PostgreSQL support

### DIFF
--- a/Blazor.POC.csproj
+++ b/Blazor.POC.csproj
@@ -4,4 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Blazor.POC.Data;
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,12 +1,23 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.EntityFrameworkCore;
+using Blazor.POC.Data;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    db.Database.EnsureCreated();
+}
 
 if (!app.Environment.IsDevelopment())
 {

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=postgres;Port=8752;Database=appdb;Username=appuser;Password=apppassword"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,18 @@ services:
     build: .
     ports:
       - "8080:8080"
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: appuser
+      POSTGRES_PASSWORD: apppassword
+      POSTGRES_DB: appdb
+    command: -p 8752
+    ports:
+      - "8752:8752"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- configure EF Core with PostgreSQL
- add default connection string and context
- include PostgreSQL service in docker-compose
- switch PostgreSQL to port 8752

## Testing
- `dotnet restore` *(fails: command not found)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aae521f0a08325b75b1f6537643667